### PR TITLE
Fix buffer allocation on node 10

### DIFF
--- a/index.js
+++ b/index.js
@@ -239,7 +239,7 @@ function collect(s) {
     return pipe(s, maybeResume(exports.through(function(data) {
         acc.push(data);
     }))).then(function() {
-        if (!acc.length) return new Buffer();
+        if (!acc.length) return Buffer.alloc(0);
         else if (typeof acc[0] === 'string')
             return acc.join('');
         else


### PR DESCRIPTION
after deprecation of new Buffer() with no arguments, this code raised this error:

	Unhandled rejection TypeError: First argument must be a string, Buffer, ArrayBuffer, Array, or array-like object.
	    at Function.Buffer.from (buffer.js:183:11)
	    at new Buffer (buffer.js:158:17)
	    at node_modules/promise-streams/index.js:242:33